### PR TITLE
Fix editing files in subdirectories + sparse-checkout edited files

### DIFF
--- a/dotfiles
+++ b/dotfiles
@@ -167,6 +167,8 @@ edit_info() {
 sparse_edit() {
     local sparse_file="$1"; shift
     local temp_dir="$(mktemp -dt dotfiles.XXXXXX)"
+    mkdir --parents "$temp_dir/$(dirname "$sparse_file")"
+    echo "!$sparse_file" >> "$dotfiles_dir"/info/sparse-checkout
     git --git-dir="$dotfiles_dir" show :"$sparse_file" 2>/dev/null > "$temp_dir/$sparse_file"
     ${EDITOR:-vim} "$temp_dir/$sparse_file"
     git --git-dir="$dotfiles_dir" update-index --add \

--- a/dotfiles
+++ b/dotfiles
@@ -56,6 +56,7 @@ sparse_tree() {
 	!LICENSE
 	!.gitattributes
 	!.gitignore
+	!.github/
 _EOF_
 }
 


### PR DESCRIPTION
Fix editing files in subdirectories. For example, the following command
fails without this fix:

    dotfiles edit .github/workflows/tests.yml

Moreover, before this commit edited files are not being ignored, which
results in this:

    $ git status
    On branch master
    You are in a sparse checkout with 97% of tracked files present.

    Changes to be committed:
      (use "git restore --staged <file>..." to unstage)
            new file:   .github/workflows/tests.yml

    Changes not staged for commit:
      (use "git add/rm <file>..." to update what will be committed)
      (use "git restore <file>..." to discard changes in working directory)
            deleted:    .github/workflows/tests.yml

    Untracked files not listed (use -u option to show untracked files)